### PR TITLE
Fix path issues and dataset requirement in tests

### DIFF
--- a/4. Modelo/predict.py
+++ b/4. Modelo/predict.py
@@ -27,7 +27,7 @@ class PredictionRequest(BaseModel):
 
 # ---------------------- Entrenamiento dinámico ----------------------
 BASE = Path(__file__).resolve().parent
-CSV = BASE.parent / "2. Extraccion de Atributos" / "OUT" / "textos_originales.csv"
+CSV = BASE.parent / "2. Extraccion de Atributos" / "out" / "textos_originales.csv"
 
 # Cargar corpus y etiquetas
 df = pd.read_csv(CSV)

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -5,7 +5,8 @@ from fastapi.testclient import TestClient
 
 import sys
 import os
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), r'..\4. Modelo')))
+model_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "4. Modelo"))
+sys.path.append(model_dir)
 from predict import app 
 
 client = TestClient(app)

--- a/tests/test_split_data.py
+++ b/tests/test_split_data.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import pandas as pd
 
 def test_split_proporcion():
-    base = Path(__file__).resolve().parent.parent / "3. Clasificador ML" / "out"
+    base = Path(__file__).resolve().parent.parent / "2. Extraccion de Atributos" / "out"
 
     df_train = pd.read_csv(base / "train.csv")
     df_val   = pd.read_csv(base / "val.csv")


### PR DESCRIPTION
## Summary
- ensure `predict.py` loads dataset from existing `out` directory
- make test modules cross-platform by fixing paths
- update dataset path in `test_split_data`

## Testing
- `pytest tests/test_predict.py::test_prediction -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b7aba8ec83268b4ec0fa1df6ebfe